### PR TITLE
Lookup optimization

### DIFF
--- a/lib/louis.rb
+++ b/lib/louis.rb
@@ -34,9 +34,8 @@ module Louis
   def self.lookup(mac)
     encoded_mac = mac_to_num(mac) & IGNORED_BITS_MASK
 
-    lookup_table.keys.each do |mask|
+    lookup_table.each do |mask, table|
       prefix = (encoded_mac & calculate_mask(nil, mask)).to_s
-      table = lookup_table[mask.to_s]
       if table.include?(prefix)
         vendor = table[prefix]
         return {'long_vendor' => vendor['l'], 'short_vendor' => vendor['s']}

--- a/lib/louis.rb
+++ b/lib/louis.rb
@@ -33,9 +33,10 @@ module Louis
   # @return [String]
   def self.lookup(mac)
     match = nil
+    encoded_mac = mac_to_num(mac) & IGNORED_BITS_MASK
 
     mask_keys.each do |mask|
-      prefix = mac_to_num(mac) & IGNORED_BITS_MASK & calculate_mask(nil, mask)
+      prefix = encoded_mac & calculate_mask(nil, mask)
       match = lookup_table[mask.to_s][prefix.to_s]
 
       break if match

--- a/lib/louis.rb
+++ b/lib/louis.rb
@@ -32,20 +32,17 @@ module Louis
   # @param [String] mac
   # @return [String]
   def self.lookup(mac)
-    match = nil
     encoded_mac = mac_to_num(mac) & IGNORED_BITS_MASK
 
-    mask_keys.each do |mask|
-      prefix = encoded_mac & calculate_mask(nil, mask)
-      match = lookup_table[mask.to_s][prefix.to_s]
-
-      break if match
+    lookup_table.keys.each do |mask|
+      prefix = (encoded_mac & calculate_mask(nil, mask)).to_s
+      table = lookup_table[mask.to_s]
+      if table.include?(prefix)
+        vendor = table[prefix]
+        return {'long_vendor' => vendor['l'], 'short_vendor' => vendor['s']}
+      end
     end
-
-    if match
-      {'long_vendor' => match['l'], 'short_vendor' => match['s']}
-    else
-      {'long_vendor' => 'Unknown', 'short_vendor' => 'Unknown'}
-    end
+    
+    {'long_vendor' => 'Unknown', 'short_vendor' => 'Unknown'}
   end
 end

--- a/spec/louis_spec.rb
+++ b/spec/louis_spec.rb
@@ -74,4 +74,10 @@ RSpec.describe Louis do
       expect(Louis.lookup(unknown_mac)['long_vendor']).to eq('Unknown')
     end
   end
+
+  describe '#mask_keys' do
+    it 'should return a list of integers: [48, 45, 44, 40, 36, 32, 28, 25, 24, 16]' do
+      expect(Louis.mask_keys).to eq([48, 45, 44, 40, 36, 32, 28, 25, 24, 16])
+    end
+  end
 end

--- a/spec/louis_spec.rb
+++ b/spec/louis_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Louis do
     expect(Louis::VERSION).not_to be nil
   end
 
-  it "it should have it's source data file" do
+  it "it should have its source data file" do
     expect(File.readable?(Louis::ORIGINAL_OUI_FILE)).to be(true)
   end
 
-  it "it should have it's parsed data file" do
+  it "it should have its parsed data file" do
     expect(File.readable?(Louis::PARSED_DATA_FILE)).to be(true)
   end
 


### PR DESCRIPTION
Louis's lookup function seemed like it could use some optimizations:

* Use a temporary variable for storing the partially-encoded mac address to avoid unnecessary AND operations per iteration

* Use _lookup_table_ which has less overhead per call than _mask_keys_

[I've run a very simple benchmark that calls Louis.lookup thousands of times to see how much overhead there is between different versions](https://gist.github.com/joshua-stone/1c9639c4c95db6c4cb0d31a97d5746b0). The original implementation finishes in roughly **5.5s** on my computer, compared to **1.6s** when using a temporary variable. Rewriting the implementation to directly use _lookup_table_ further improves performance, as the benchmark can now complete in **0.88s** making for a **6.25x speedup**.

