### PR TITLE
Fixing nil error

### DIFF
--- a/lib/louis.rb
+++ b/lib/louis.rb
@@ -32,16 +32,18 @@ module Louis
   # @param [String] mac
   # @return [String]
   def self.lookup(mac)
-    encoded_mac = mac_to_num(mac) & IGNORED_BITS_MASK
+    if mac.is_a? String
+      encoded_mac = mac_to_num(mac) & IGNORED_BITS_MASK
 
-    lookup_table.each do |mask, table|
-      prefix = (encoded_mac & calculate_mask(nil, mask)).to_s
-      if table.include?(prefix)
-        vendor = table[prefix]
-        return {'long_vendor' => vendor['l'], 'short_vendor' => vendor['s']}
+      lookup_table.each do |mask, table|
+        prefix = (encoded_mac & calculate_mask(nil, mask)).to_s
+        if table.include?(prefix)
+          vendor = table[prefix]
+          return {'long_vendor' => vendor['l'], 'short_vendor' => vendor['s']}
+        end
       end
     end
-    
+
     {'long_vendor' => 'Unknown', 'short_vendor' => 'Unknown'}
   end
 end


### PR DESCRIPTION
[As pointed out by a bug report, Louis.lookup doesn't handle nil elegantly](https://github.com/pwnieexpress/louis/issues/1). I think it'd be sensible to explicitly have it accept only strings early in the method call, and use `{'long_vendor' => 'Unknown', 'short_vendor' => 'Unknown'}` as a fallback for nil and any other non-string types instead of causing a NoMethodError that has to be handled in top level application code.