### PR TITLE
Fix travis config by not using broken RVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: ruby
 cache: bundler
-rvm:
-  - 2.1.5


### PR DESCRIPTION
Going to :us: this as it doesn't effect any code functionality. PR existed to trigger travis build